### PR TITLE
Release v0.1.0 - Take 2

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "master"
+      - "main"
   
 jobs:
   git-release:

--- a/.github/workflows/git-release.yml
+++ b/.github/workflows/git-release.yml
@@ -16,7 +16,7 @@ jobs:
         shell: bash
         id: semver
         run: |
-          export SEMVER=`echo "${{ github.event.head_commit.message }}" | grep -i "release-" | cut -d '-' -f 2 | head -n 1`
+          export SEMVER=`echo "${{ github.event.workflow_run.head_commit.message }}" | grep -i "release-" | cut -d '-' -f 2 | head -n 1`
           echo "value=$SEMVER" >> $GITHUB_OUTPUT
 
       - uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/git-release.yml
+++ b/.github/workflows/git-release.yml
@@ -18,7 +18,7 @@ jobs:
         shell: bash
         id: semver
         run: |
-          export SEMVER=`echo "${{ github.event.workflow_run.head_commit.message }}" | grep -i "release-" | cut -d '-' -f 2 | head -n 1`
+          export SEMVER=`echo "${{ github.event.head_commit.message }}" | grep -i "release-" | cut -d '-' -f 2 | head -n 1`
           echo "value=$SEMVER" >> $GITHUB_OUTPUT
 
       # - uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/git-release.yml
+++ b/.github/workflows/git-release.yml
@@ -1,5 +1,7 @@
 name: git-release
 on:
+  workflow_dispatch:
+    
   workflow_call:
     outputs:
       semver: 
@@ -19,10 +21,10 @@ jobs:
           export SEMVER=`echo "${{ github.event.workflow_run.head_commit.message }}" | grep -i "release-" | cut -d '-' -f 2 | head -n 1`
           echo "value=$SEMVER" >> $GITHUB_OUTPUT
 
-      - uses: "marvinpinto/action-automatic-releases@latest"
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${{ steps.semver.outputs.value }}"
-          prerelease: false
-          draft: false
-          title: "Release ${{ steps.semver.outputs.value }}"
+      # - uses: "marvinpinto/action-automatic-releases@latest"
+      #   with:
+      #     repo_token: "${{ secrets.GITHUB_TOKEN }}"
+      #     automatic_release_tag: "${{ steps.semver.outputs.value }}"
+      #     prerelease: false
+      #     draft: false
+      #     title: "Release ${{ steps.semver.outputs.value }}"

--- a/.github/workflows/git-release.yml
+++ b/.github/workflows/git-release.yml
@@ -21,10 +21,10 @@ jobs:
           export SEMVER=`echo "${{ github.event.head_commit.message }}" | grep -i "release-" | cut -d '-' -f 2 | head -n 1`
           echo "value=$SEMVER" >> $GITHUB_OUTPUT
 
-      # - uses: "marvinpinto/action-automatic-releases@latest"
-      #   with:
-      #     repo_token: "${{ secrets.GITHUB_TOKEN }}"
-      #     automatic_release_tag: "${{ steps.semver.outputs.value }}"
-      #     prerelease: false
-      #     draft: false
-      #     title: "Release ${{ steps.semver.outputs.value }}"
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ steps.semver.outputs.value }}"
+          prerelease: false
+          draft: false
+          title: "Release ${{ steps.semver.outputs.value }}"

--- a/.github/workflows/git-release.yml
+++ b/.github/workflows/git-release.yml
@@ -1,7 +1,5 @@
 name: git-release
 on:
-  workflow_dispatch:
-    
   workflow_call:
     outputs:
       semver: 


### PR DESCRIPTION
Seems like github.event.head_commit.message is not available on workflow dispatches. Since the push criteria for ./.github/workflows/deploy-production.yml was incorrect, (Was looking for pushes to master when our branch is "main".) the commit message was never available. 

By fixing the push criteria, the release workflow _should_ work correctly now.