### PR TITLE
Install datadog last to avoid host lockup.

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -53,12 +53,6 @@
       tags: docker
       become: true
 
-    - name: Configure Datadog
-      import_role:
-        name: datadog.dd.agent
-      tags: datadog
-      become: true
-
     - name: Setup Website
       block:
         - name: Start container
@@ -80,3 +74,9 @@
           tags: caddy
           become: true
       tags: app
+
+    - name: Configure Datadog
+      import_role:
+        name: datadog.dd.agent
+      tags: datadog
+      become: true


### PR DESCRIPTION
PR attempts to address Issue #17. Skipping a release as moving forward, only python code changes will increase version.