### PR TITLE
Release v0.2.2

### DIFF
--- a/.github/workflows/ansible-deploy.yml
+++ b/.github/workflows/ansible-deploy.yml
@@ -3,6 +3,11 @@ name: Deploy with Ansible
 
 on:
   workflow_call:
+    inputs:
+      IMAGE_VERSION:
+        type: string
+        required: false
+        description: "Container image tag to deploy"
     secrets:
       GCP_SERVICE_ACCOUNT_CONTENTS:
         required: true
@@ -16,6 +21,10 @@ on:
 
   workflow_dispatch:
     inputs:
+      IMAGE_VERSION:
+        type: string
+        required: false
+        description: "Container image tag to deploy"
       tags:
         description: 'Ansible tags to limit task execution.'
         required: false
@@ -48,3 +57,4 @@ jobs:
             --inventory inventory.gcp.yaml ${{ github.event.inputs.tags && format('-t {}', github.event.inputs.tags) || '' }}
         env:
           GCP_SERVICE_ACCOUNT_CONTENTS: "${{secrets.GCP_SERVICE_ACCOUNT_CONTENTS}}"
+          IMAGE_VERSION: "${{inputs.IMAGE_VERSION}}"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,8 +32,9 @@ jobs:
       TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
 
   ansible-deploy:
-    needs: [terraform-apply, build-docker-image]
+    needs: [terraform-apply, git-release, build-docker-image]
     uses: ./.github/workflows/ansible-deploy.yml
+    with: ${{ needs.git-release.outputs.semver }}
     secrets:
       GCP_SERVICE_ACCOUNT_CONTENTS: "${{secrets.GCP_SERVICE_ACCOUNT_CONTENTS}}"
       SSH_PRIVATE_KEY: "${{secrets.SSH_PRIVATE_KEY}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install -r /app/requirements.txt
 EXPOSE 8080
 
 # Set Environment Variables to Configure Datadog APM Tracing
-ENV DD_LOGS_INJECTION=true DD_PROFILING_ENABLED=true DD_APPSEC_ENABLED=true DD_APPSEC_SCA_ENABLED=true
+ENV DD_LOGS_INJECTION=true DD_PROFILING_ENABLED=true DD_APPSEC_ENABLED=true DD_APPSEC_SCA_ENABLED=true DD_AGENT_HOST=host.docker.internal
 CMD ["ddtrace-run", "gunicorn", "cloud_resume.app:app"]

--- a/ansible/group_vars/webserver.yaml
+++ b/ansible/group_vars/webserver.yaml
@@ -11,6 +11,7 @@ datadog_api_key: !vault |
 datadog_config:
   apm_config:
     enabled: true
+    apm_non_local_traffic: true
   logs_enabled: true
   logs_config:
     container_collect_all: true

--- a/ansible/group_vars/webserver.yaml
+++ b/ansible/group_vars/webserver.yaml
@@ -12,6 +12,7 @@ datadog_config:
   apm_config:
     enabled: true
     apm_non_local_traffic: true
+  dogstatsd_non_local_traffic: true
   logs_enabled: true
   logs_config:
     container_collect_all: true

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -5,7 +5,8 @@
     ansible_user: ansible
     webserver_fqdn: "resume.sbrtech.xyz"
     webserver_port: 8080
-    webserver_image: ghcr.io/sbrupert/cloud-resume
+    webserver_image_version: "{{ lookup('ansible.builtin.env', 'IMAGE_VERSION') | default('latest', true) }}"
+    webserver_image: ghcr.io/sbrupert/cloud-resume:{{webserver_image_version}}
     letsencrypt_staging: true
 
   handlers:

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -63,6 +63,8 @@
             restart_policy: "always"
             pull: "always"
             published_ports: "8080:{{ webserver_port }}"
+            etc_hosts:
+              host.docker.internal: host-gateway
             labels:
               com.datadoghq.tags.env: cloud-resume-prod
               com.datadoghq.tags.service: resume-website

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -2,7 +2,7 @@ resource "cloudflare_record" "cloud_resume" {
   zone_id = var.cloudflare_zone_id
   name = var.webserver_subdomain
   # This dynamically sets the value of our DNS record to whatever the public IP of our GCP instance is.
-  value = resource.google_compute_instance.web01.network_interface.0.access_config.0.nat_ip
+  content = resource.google_compute_instance.web01.network_interface.0.access_config.0.nat_ip
   type = "A"
   proxied = false
   # Prevents the record from being created before our GCP instance. Which would cause the run to fail.


### PR DESCRIPTION
* (Bugfix) Fix the dd-trace agent not being able to send traces to the host datadog-agent. (Fixes #26)
* (Bugfix) Switch to a non-depreciated parameter for the cloudflare_record terraform resource.
* (Enhancement) Add image version variable to explicitly set deployed container image.