### PR TITLE
Release v.0.2.2 - Take 2

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -34,7 +34,8 @@ jobs:
   ansible-deploy:
     needs: [terraform-apply, git-release, build-docker-image]
     uses: ./.github/workflows/ansible-deploy.yml
-    with: ${{ needs.git-release.outputs.semver }}
+    with: 
+      IMAGE_VERSION: ${{ needs.git-release.outputs.semver }}
     secrets:
       GCP_SERVICE_ACCOUNT_CONTENTS: "${{secrets.GCP_SERVICE_ACCOUNT_CONTENTS}}"
       SSH_PRIVATE_KEY: "${{secrets.SSH_PRIVATE_KEY}}"


### PR DESCRIPTION
* (Bugfix) Fix the dd-trace agent not being able to send traces to the host datadog-agent. (Fixes #26)
* (Bugfix) Switch to a non-depreciated parameter for the cloudflare_record terraform resource.
* (Enhancement) Add image version variable to explicitly set deployed container image.