### PR TITLE
Fix Datadog Universal Service Tags

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -51,6 +51,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args:
+            - VERSION=${{env.IMAGE_VERSION}}
       
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:22.04
 
+ARG VERSION
+
 WORKDIR /app
 RUN apt-get update -y && apt-get install -y python3 python3-pip
 
@@ -12,5 +14,5 @@ RUN pip install -r /app/requirements.txt
 EXPOSE 8080
 
 # Set Environment Variables to Configure Datadog APM Tracing
-ENV DD_LOGS_INJECTION=true DD_PROFILING_ENABLED=true DD_APPSEC_ENABLED=true DD_APPSEC_SCA_ENABLED=true DD_AGENT_HOST=host.docker.internal
+ENV DD_LOGS_INJECTION=true DD_PROFILING_ENABLED=true DD_APPSEC_ENABLED=true DD_APPSEC_SCA_ENABLED=true DD_AGENT_HOST=host.docker.internal DD_ENV=${VERSION}
 CMD ["ddtrace-run", "gunicorn", "cloud_resume.app:app"]

--- a/ansible/group_vars/webserver.yaml
+++ b/ansible/group_vars/webserver.yaml
@@ -28,14 +28,6 @@ network_config:
   enabled: true
 
 datadog_additional_groups: docker
-# Datadog APM Config for Auto APM with Docker
-datadog_apm_instrumentation_enabled: all
-datadog_apm_instrumentation_libraries: ["python"]
-datadog_apm_instrumentation_docker_config:
-  log_level: info
-  output_paths:
-    - stderr
-  config_sources: BASIC
 
 datadog_checks:
   docker:

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -65,6 +65,9 @@
             restart_policy: "always"
             pull: "always"
             published_ports: "8080:{{ webserver_port }}"
+            env:
+              DD_SERVICE: resume-website
+              DD_ENV: cloud-resume-prod
             etc_hosts:
               host.docker.internal: host-gateway
             labels:


### PR DESCRIPTION
This PR disables Datadog auto APM injection and defines the Datadog [Universal Service Tags (UST) ](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes) for our application.

The DD_VERSION tag is defined as apart of the image build. DD_SERVICE and DD_ENV are defined as environment variables when the container is launched. 

This was done as version is not something that should be changed post build time. Whereas service and env could theoretically change. (Service maybe not so much...)