### PR TITLE
Release v0.2.2 - Ignore changes to base image updates.

### DIFF
--- a/terraform/google.tf
+++ b/terraform/google.tf
@@ -40,6 +40,10 @@ resource "google_compute_instance" "web01" {
     email = google_service_account.webserver_sa.email
     scopes = ["cloud-platform"]
   }
+
+  lifecycle {
+    ignore_changes = [ boot_disk.initialize_params.image ]
+  }
 }
 
 # Firestore Related Resources

--- a/terraform/google.tf
+++ b/terraform/google.tf
@@ -42,7 +42,7 @@ resource "google_compute_instance" "web01" {
   }
 
   lifecycle {
-    ignore_changes = [ boot_disk[0].initialize_params.image ]
+    ignore_changes = [ boot_disk[0].initialize_params[0].image ]
   }
 }
 

--- a/terraform/google.tf
+++ b/terraform/google.tf
@@ -42,7 +42,7 @@ resource "google_compute_instance" "web01" {
   }
 
   lifecycle {
-    ignore_changes = [ boot_disk.initialize_params.image ]
+    ignore_changes = [ boot_disk[0].initialize_params.image ]
   }
 }
 


### PR DESCRIPTION
Updates to the instance base image are forcing a replacement in terraform. Ignoring these changes will prevent a replacement.