### PR TITLE
Disable datadog NPM to prevent resource starvation.

### DIFF
--- a/ansible/group_vars/webserver.yaml
+++ b/ansible/group_vars/webserver.yaml
@@ -25,7 +25,7 @@ datadog_config:
       polling: true
   
 network_config:
-  enabled: true
+  enabled: false
 
 datadog_additional_groups: docker
 


### PR DESCRIPTION
Testing Datadog NPM enabled vs disabled showed a massive difference in system performance:
<img width="589" height="238" alt="image" src="https://github.com/user-attachments/assets/a45cd86e-c2c2-4dd1-98e3-8068d34a6b98" />

Performance has been stable since disabling the feature a day ago.