### PR TITLE
[Bugfix] update expired cache

### DIFF
--- a/cloud_resume/cloud_resume/db.py
+++ b/cloud_resume/cloud_resume/db.py
@@ -72,7 +72,7 @@ class FirestoreClient():
                 visitor_count = doc.to_dict().get('count')
                 return visitor_count
             else:
-                logger.error("Counter document does not exist!")
+                logger.warning("Counter document does not exist!")
                 return None
         except Exception as e:
             logger.error(f"Error retrieving visitor count from Firestore database: {e}")

--- a/cloud_resume/cloud_resume/db.py
+++ b/cloud_resume/cloud_resume/db.py
@@ -195,7 +195,7 @@ def cache_ip():
                 logger.debug(f"IP {client_ip} found in cache and not expired.")
                 return True
             else:
-                logger.debug(f"IP {client_ip} found in cache but expired.")
+                logger.debug(f"IP {client_ip} found in cache but expired. Updating timestamp in cache and database.")
                 ip_cache[client_ip] = current_time
                 database.update_visitor_ip(client_ip, current_time)
                 return False

--- a/cloud_resume/cloud_resume/db.py
+++ b/cloud_resume/cloud_resume/db.py
@@ -186,11 +186,12 @@ def cache_ip():
     global database
     client_ip = get_client_ip()
     current_time = datetime.now(timezone.utc)
+    expiration_threshold = current_time - timedelta(hours=24)
 
     try:
         if client_ip in ip_cache:
             cache_timestamp = ip_cache[client_ip]
-            if cache_timestamp >= (current_time - timedelta(days=1)):
+            if cache_timestamp >= expiration_threshold:
                 logger.debug(f"IP {client_ip} found in cache and not expired.")
                 return True
             else:
@@ -205,7 +206,7 @@ def cache_ip():
 
         if db_ip[0] == True:
             db_timestamp = db_ip[1]['timestamp']
-            if db_timestamp >= (current_time - timedelta(days=1)):
+            if db_timestamp >= expiration_threshold:
                 ip_cache[client_ip] = db_timestamp
                 logger.debug(f"IP {client_ip} found in database and not expired.")
                 return True

--- a/cloud_resume/cloud_resume/db.py
+++ b/cloud_resume/cloud_resume/db.py
@@ -116,7 +116,7 @@ class FirestoreClient():
                 content = doc.to_dict()
                 return True, content
             else:
-                logger.warning(f"Visitor document does not exist for ip {ip_address}!")
+                logger.debug(f"Visitor document does not exist for ip {ip_address}!")
                 return False, None
         except Exception as e:
             logger.error(f"Error retrieving visitor ip address from Firestore database! {e}")

--- a/cloud_resume/cloud_resume/db.py
+++ b/cloud_resume/cloud_resume/db.py
@@ -195,6 +195,8 @@ def cache_ip():
                 return True
             else:
                 logger.debug(f"IP {client_ip} found in cache but expired.")
+                ip_cache[client_ip] = current_time
+                database.update_visitor_ip(client_ip, current_time)
                 return False
         else:
             logger.debug(f"IP {client_ip} not found in cache. Checking database.")

--- a/cloud_resume/tests/app/test_app.py
+++ b/cloud_resume/tests/app/test_app.py
@@ -1,6 +1,6 @@
 import pytest
 import cloud_resume.app as cloud_resume
-from cloud_resume.db import FirestoreClient
+import cloud_resume.db as db
 from flask import request
 from datetime import datetime, timezone, timedelta
 
@@ -44,9 +44,36 @@ def test_counter_integration(setup_firestore_emulator, client, monkeypatch, mock
 
     # Counter should increment when user visits 24 hours later.
     one_day_ago = datetime.now(timezone.utc) - timedelta(days=1)
-    database = FirestoreClient()
+    database = db.FirestoreClient()
     database.connect_to_firestore()
     database._db.collection('visitor_ips').document('10.0.10.1').set({'timestamp': one_day_ago})
     monkeypatch.setattr('cloud_resume.db.ip_cache', {})
     response = client.get('/', headers={"X-Forwarded-For": "10.0.10.1"})
     assert b'<b>You are visitor number: 3' in response.data
+
+def test_counter_integration_stale_ip_cache_only_increments_once(setup_firestore_emulator, client, monkeypatch, mocker):
+    """
+    Tests the counter integration for stale ip_cache entries.
+
+    This test checks that the visitor counter is only incremented once when the client IP is already
+    present in ip_cache with an expired timestamp.
+    """
+    firestore_port = setup_firestore_emulator
+    monkeypatch.setenv('FIRESTORE_EMULATOR_HOST', f'localhost:{firestore_port}')
+    monkeypatch.setattr(db.database, "_db", None)
+
+    client_ip = "10.0.10.2"
+    one_day_ago = datetime.now(timezone.utc) - timedelta(days=2)
+    database = db.FirestoreClient()
+    database.connect_to_firestore()
+
+    database._db.collection('counters').document('visitor_count').set({'count': 10})
+    database._db.collection('visitor_ips').document(client_ip).set({'timestamp': one_day_ago})
+    monkeypatch.setattr('cloud_resume.db.ip_cache', {client_ip: one_day_ago})
+    monkeypatch.setattr('cloud_resume.db.counter_cache', None)
+
+    response = client.get('/', headers={"X-Forwarded-For": client_ip})
+    assert b'<b>You are visitor number: 11' in response.data
+
+    response = client.get('/', headers={"X-Forwarded-For": client_ip})
+    assert b'<b>You are visitor number: 11' in response.data

--- a/cloud_resume/tests/db/test_cache_ip_expired_cache.py
+++ b/cloud_resume/tests/db/test_cache_ip_expired_cache.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timedelta, timezone
+import cloud_resume.db as db
+
+def test_cache_ip_updates_firestore_when_local_cache_entry_is_expired(
+    mocker, monkeypatch
+):
+    """
+    If the client IP is found in the local ip_cache but the cached timestamp is
+    older than 24 hours, the app should refresh the timestamp in Firestore and
+    refresh the local cache entry.
+    """
+    client_ip = "192.168.1.1"
+    current_time = datetime.now(timezone.utc)
+    expired_time = current_time - timedelta(days=2)
+    db_state = { client_ip: {"timestamp": expired_time}}
+    
+    def fake_update_visitor_ip(ip_address, timestamp):
+        db_state[ip_address] = {"timestamp": timestamp}
+        return True
+
+    mock_update_visitor_ip = mocker.patch.object(
+        db.FirestoreClient,
+        "update_visitor_ip",
+        side_effect=fake_update_visitor_ip,
+    )
+
+    mocker.patch("cloud_resume.db.get_client_ip", return_value=client_ip)
+
+    monkeypatch.setattr(
+        "cloud_resume.db.ip_cache",
+        {client_ip: expired_time},
+    )
+
+    result = db.cache_ip()
+
+    # cache_ip() should return False on expired cache items.
+    assert result is False
+
+    # Firestore should be updated with the new timestamp for the expired IP.
+    mock_update_visitor_ip.assert_called_once_with(client_ip, db.ip_cache[client_ip])
+
+    # Firestore should have timestamp updated and equal to the cache's value.
+    assert db_state[client_ip]["timestamp"] > expired_time
+    assert db.ip_cache[client_ip] == db_state[client_ip]["timestamp"]

--- a/cloud_resume/tests/db/test_increment_counter.py
+++ b/cloud_resume/tests/db/test_increment_counter.py
@@ -1,5 +1,7 @@
 import pytest
+from datetime import datetime, timedelta, timezone
 from cloud_resume.db import increment_counter, FirestoreClient
+from cloud_resume import db
 
 @pytest.mark.parametrize("cache_result, counter_cache, database_visitor_count, expected_result",[
     (True, 5, None, 5),             # Scenario 1: Cache hit, use cached counter.
@@ -42,3 +44,49 @@ def test_increment_counter_exception(mocker, monkeypatch):
     mocker.patch('cloud_resume.db.cache_ip', side_effect=Exception("Mock DB error"))
     
     assert increment_counter() == "Unavailable"
+
+def test_increment_counter_only_increments_once_for_expired_cached_ip(mocker, monkeypatch):
+    client_ip = "192.168.1.1"
+    current_time = datetime.now(timezone.utc)
+    expired_time = current_time - timedelta(days=2)
+
+    counter_state = {"count": 10}
+    db_state = {client_ip: {"timestamp": expired_time}}
+
+    def fake_update_visitor_ip(ip_address, timestamp):
+        db_state[ip_address] = {"timestamp": timestamp}
+        return True
+    
+    def fake_get_visitor_count():
+        return counter_state["count"]
+    
+    def fake_update_visitor_count(count):
+        counter_state["count"] = count
+    
+    mocker.patch("cloud_resume.db.get_client_ip", return_value=client_ip)
+    
+    mocker.patch.object(
+        db.FirestoreClient,
+        "update_visitor_ip",
+        side_effect=fake_update_visitor_ip,
+    )
+    mock_get_visitor_count = mocker.patch.object(
+        db.FirestoreClient,
+        "get_visitor_count",
+        side_effect=fake_get_visitor_count,
+    )
+    mock_update_visitor_count = mocker.patch.object(
+        db.FirestoreClient,
+        "update_visitor_count",
+        side_effect=fake_update_visitor_count,
+    )
+
+    monkeypatch.setattr("cloud_resume.db.ip_cache", {client_ip: expired_time})
+    monkeypatch.setattr("cloud_resume.db.counter_cache", None)
+
+    first_result = db.increment_counter()
+    second_result = db.increment_counter()
+
+    assert first_result == 11
+    assert second_result == 11
+    mock_update_visitor_count.assert_called_once_with(11)  

--- a/cloud_resume/tests/db/test_increment_counter.py
+++ b/cloud_resume/tests/db/test_increment_counter.py
@@ -1,6 +1,5 @@
 import pytest
 from datetime import datetime, timedelta, timezone
-from cloud_resume.db import increment_counter, FirestoreClient
 from cloud_resume import db
 
 @pytest.mark.parametrize("cache_result, counter_cache, database_visitor_count, expected_result",[
@@ -27,10 +26,10 @@ def test_increment_counter_cache(mocker, monkeypatch, cache_result, counter_cach
     """
     monkeypatch.setattr("cloud_resume.db.counter_cache", counter_cache)
     mocker.patch('cloud_resume.db.cache_ip', return_value=cache_result)
-    mocker.patch.object(FirestoreClient, "get_visitor_count", return_value = database_visitor_count)
-    mocker.patch.object(FirestoreClient, "update_visitor_count", return_value = None)
+    mocker.patch.object(db.FirestoreClient, "get_visitor_count", return_value = database_visitor_count)
+    mocker.patch.object(db.FirestoreClient, "update_visitor_count", return_value = None)
     
-    assert increment_counter() == expected_result
+    assert db.increment_counter() == expected_result
 
 
 def test_increment_counter_exception(mocker, monkeypatch):
@@ -43,7 +42,7 @@ def test_increment_counter_exception(mocker, monkeypatch):
     monkeypatch.setattr("cloud_resume.db.counter_cache", None)
     mocker.patch('cloud_resume.db.cache_ip', side_effect=Exception("Mock DB error"))
     
-    assert increment_counter() == "Unavailable"
+    assert db.increment_counter() == "Unavailable"
 
 def test_increment_counter_only_increments_once_for_expired_cached_ip(mocker, monkeypatch):
     client_ip = "192.168.1.1"

--- a/cloud_resume/tests/db/test_increment_counter.py
+++ b/cloud_resume/tests/db/test_increment_counter.py
@@ -45,6 +45,11 @@ def test_increment_counter_exception(mocker, monkeypatch):
     assert db.increment_counter() == "Unavailable"
 
 def test_increment_counter_only_increments_once_for_expired_cached_ip(mocker, monkeypatch):
+    """
+    Tests the increment_counter() function for proper counter increment behavior.
+
+    This test checks that the visitor counter is only incremented once when the client IP is already present in ip_cache with an expired timestamp.
+    """
     client_ip = "192.168.1.1"
     current_time = datetime.now(timezone.utc)
     expired_time = current_time - timedelta(days=2)


### PR DESCRIPTION
## Summary

Fixes the visitor counter bug where returning users could increment the counter on every page refresh after their cached IP entry became older than 24 hours.

This change updates the expired `ip_cache` branch in `cache_ip()` so that when a cached IP is stale, its timestamp is refreshed in both `ip_cache` and Firestore before returning control to `increment_counter()`. This preserves the intended behavior: increment once after the 24 hour threshold, then stop incrementing on subsequent refreshes.

## Changes

- Update `cache_ip()` to refresh expired IP entries already present in `ip_cache`
- Introduce `expiration_threshold` to make cache expiry comparisons clearer
- Add a unit test covering expired cached IP handling in `cache_ip()`
- Add a regression test covering `increment_counter()` behavior for expired cached IP entries
- Add a route-level integration test covering stale `ip_cache` behavior end to end
- Downgrade noisy log levels for missing visitor and counter documents
- Standardize test imports to use the module namespace where needed

## Testing

- Ran focused DB tests covering:
  - `cache_ip()` return behavior
  - expired cached IP refresh behavior
  - `increment_counter()` stale-cache regression behavior
- Ran app integration tests with the Firestore emulator
- Verified the stale `ip_cache` path increments the counter once and does not continue incrementing on immediate refresh

## Root Cause

The bug occurred because `cache_ip()` returned `False` immediately when a `client_ip` was found in `ip_cache` with an expired timestamp. That branch did not refresh the timestamp in Firestore or the local cache, so the same IP could continue being treated as expired on every page load.

## Issue

Closes #42
